### PR TITLE
Refactor question and room calculations into services

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Response.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Response.razor
@@ -190,7 +190,7 @@
                     <span>&nbsp;</span>
                     @if (proposalRows?.Any() == true)
                     {
-                        <RadzenButton Text="Re-Calculate" Icon="calculate" Style="margin-top: 4px; background-color: green;" ButtonStyle="ButtonStyle.Primary" Click="ReCalculateProposal" />
+                        <RadzenButton Text="Re-Calculate" Icon="calculate" Style="margin-top: 4px; background-color: green;" ButtonStyle="ButtonStyle.Primary" Click="OnReCalculateProposal" />
                         <br />
                         <RadzenDataGrid @ref="grid" Data="@proposalRows" TItem="ProposalRow" EditMode="DataGridEditMode.Single" Editable="true" Style="margin-top:20px">
                             <Columns>
@@ -796,6 +796,21 @@
         }
     }
 
+    private async Task OnReCalculateProposal()
+    {
+        try
+        {
+            InProgress = true;
+            StateHasChanged();
+            roomOptions = await Calculations.ReCalculateProposal(proposalRows, LogService, NotificationService);
+        }
+        finally
+        {
+            InProgress = false;
+            StateHasChanged();
+        }
+    }
+
     async Task EditRow(ProposalRow row) => await grid.EditRow(row);
 
     private Table BuildProposalTable(IEnumerable<ProposalRow> rows)
@@ -1335,43 +1350,6 @@
     }
     #endregion
 
-    private async Task<List<QuestionResponse>> IdentifyQuestions()
-    {
-        List<QuestionResponse> _IdentifiedQuestions = new List<QuestionResponse>();
-
-        try
-        {
-            var prompt = await Http.GetStringAsync("Prompts/IdentifyQuestions.prompt");
-            prompt = prompt.Replace("{{RFPText}}", RFPText ?? string.Empty);
-
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] IdentifyQuestions: Sending prompt to AI...");
-
-            var objOrchestratorMethods = new OrchestratorMethods(_SettingsService, LogService);
-            var settingsService = new SettingsService();
-
-            var response = await objOrchestratorMethods.CallOpenAIAsync(settingsService, prompt);
-
-            // Log response length
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] IdentifyQuestions: AI response length: {response.Response?.Length ?? 0}");
-
-            if (string.IsNullOrWhiteSpace(response.Error))
-            {
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] IdentifyQuestions: Attempting to deserialize JSON response");
-                _IdentifiedQuestions = JsonConvert.DeserializeObject<List<QuestionResponse>>(response.Response) ?? new List<QuestionResponse>();
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] IdentifyQuestions: Deserialized {_IdentifiedQuestions.Count} questions");
-            }
-            else
-            {
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: IdentifyQuestions failed - {response.Error}");
-            }
-        }
-        catch (Exception ex)
-        {
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in IdentifyQuestions - {ex.Message}");
-        }
-
-        return _IdentifiedQuestions;
-    }
 
     private async Task OnProposalUpload(UploadChangeEventArgs e)
     {
@@ -1539,7 +1517,8 @@
             }
             StateHasChanged();
 
-            var questionsFromAI = await IdentifyQuestions();
+            var questionProcessor = new QuestionProcessing(Http, _SettingsService, LogService);
+            var questionsFromAI = await questionProcessor.IdentifyQuestions(RFPText);
 
             // No need to convert since IdentifyQuestions now returns List<QuestionResponse>
             identifiedQuestions = questionsFromAI ?? new List<QuestionResponse>();
@@ -1582,7 +1561,11 @@
             {
                 CurrentStatus = "Detect Room Requests...";
                 StateHasChanged();
-                await DetectRoomRequests();
+                var detectResult = await Calculations.DetectRoomRequests(RFPText, Http, _SettingsService, LogService, NotificationService, SaveProposalRowsAsync, SortProposalRows);
+                result = detectResult.result;
+                processedText = detectResult.processedText;
+                proposalRows = detectResult.proposalRows;
+                roomOptions = detectResult.roomOptions;
             }
 
             NotificationService.Notify(new NotificationMessage
@@ -1611,367 +1594,9 @@
         }
     }
 
-    private async Task CalculateRoomsForExistingRows()
-    {
-        try
-        {
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] CalculateRoomsForExistingRows started with {proposalRows?.Count ?? 0} rows");
 
-            if (proposalRows == null || !proposalRows.Any())
-            {
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] No existing proposal rows found");
-                NotificationService.Notify(new NotificationMessage
-                {
-                    Severity = NotificationSeverity.Warning,
-                    Summary = "Warning",
-                    Detail = "No proposal rows found. Please add some rows or upload a proposal first.",
-                    Duration = 4000
-                });
-                return;
-            }
 
-            // Filter rows that need room assignments
-            // #2: Ignore any ProposalRow that has ManualRoom set to any value other than null or empty string
-            var rowsNeedingRooms = proposalRows.Where(row =>
-                string.IsNullOrWhiteSpace(row.ManualRoom) &&
-                string.IsNullOrWhiteSpace(row.SelectedRoom)).ToList();
 
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] Found {rowsNeedingRooms.Count} rows needing room assignments");
-
-            if (!rowsNeedingRooms.Any())
-            {
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] No rows require room assignments");
-                NotificationService.Notify(new NotificationMessage
-                {
-                    Severity = NotificationSeverity.Info,
-                    Summary = "Info",
-                    Detail = "All rows already have room assignments or manual room overrides.",
-                    Duration = 4000
-                });
-                return;
-            }
-
-            // Convert ProposalRows to RoomsRequests
-            var requests = rowsNeedingRooms.Select(row => new RoomsRequest
-            {
-                Name = row.Name ?? "Unknown",
-                StartDate = row.StartDate,
-                StartTime = row.StartTime,
-                EndDate = row.EndDate,
-                EndTime = row.EndTime,
-                RoomType = row.RoomType ?? "",
-                Attendance = row.Attendance,
-                Notes = row.Notes ?? ""
-            }).ToList();
-
-            // Create JSON for the calculator
-            var requestsJson = JsonConvert.SerializeObject(requests);
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] Created requests JSON for calculation: {requestsJson.Substring(0, Math.Min(500, requestsJson.Length))}");
-
-            // Calculate room assignments
-            var calculator = new CalculateProposal("/RFPResponseAPP", LogService);
-            var assignments = await calculator.CalculateAsync(requestsJson);
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] Calculator returned {assignments?.Count ?? 0} assignments");
-
-            // Update the proposal rows with calculated room assignments
-            var assignmentDict = assignments.ToDictionary(a => a.Request?.Name ?? "", a => a.AssignedRoom);
-
-            foreach (var row in rowsNeedingRooms)
-            {
-                if (assignmentDict.TryGetValue(row.Name ?? "", out var assignedRoom) && !string.IsNullOrWhiteSpace(assignedRoom))
-                {
-                    row.SelectedRoom = assignedRoom;
-                    await LogService.WriteToLogAsync($"[{DateTime.Now}] Assigned room '{assignedRoom}' to row '{row.Name}'");
-                }
-                else
-                {
-                    await LogService.WriteToLogAsync($"[{DateTime.Now}] No room assigned for row '{row.Name}'");
-                }
-            }
-
-            // Load room options for dropdown
-            try
-            {
-                var capacityJson = await File.ReadAllTextAsync("/RFPResponseAPP/Capacity.json");
-                var capacity = JsonConvert.DeserializeObject<CapacityRoot>(capacityJson);
-                roomOptions = capacity?.Rooms?.Select(r => r.Name).OrderBy(n => n).ToList() ?? new List<string>();
-            }
-            catch (Exception ex)
-            {
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] WARNING: Unable to load Capacity.json - {ex.Message}");
-                roomOptions = new List<string>();
-            }
-
-            // Save the updated proposal rows and refresh UI
-            SortProposalRows();
-            await SaveProposalRowsAsync();
-            StateHasChanged();
-
-            var assignedCount = rowsNeedingRooms.Count(row => !string.IsNullOrWhiteSpace(row.SelectedRoom));
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] CalculateRoomsForExistingRows completed - assigned {assignedCount} of {rowsNeedingRooms.Count} rooms");
-
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Success,
-                Summary = "Success",
-                Detail = $"Room calculation completed. Assigned {assignedCount} of {rowsNeedingRooms.Count} rooms.",
-                Duration = 4000
-            });
-        }
-        catch (Exception ex)
-        {
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in CalculateRoomsForExistingRows - {ex.Message}");
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {ex.StackTrace}");
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Error,
-                Summary = "Error",
-                Detail = $"Failed to calculate rooms: {ex.Message}",
-                Duration = 8000
-            });
-        }
-        finally
-        {
-            InProgress = false;
-            StateHasChanged();
-        }
-    }
-
-    private async Task CalculateProposal()
-    {
-        try
-        {
-            InProgress = true;
-            CurrentStatus = "Calculating...";
-            StateHasChanged();
-
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] CalculateProposal method started");
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] RFPText content length: {RFPText?.Length ?? 0}");
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] RFPText content (first 1000 chars): {RFPText?.Substring(0, Math.Min(1000, RFPText?.Length ?? 0))}");
-
-            string processedJsonText = processedText;
-
-            try
-            {
-                var testParse = JsonConvert.DeserializeObject(processedText);
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] JSON parsing test successful. Object type: {testParse?.GetType().Name}");
-                if (testParse is Newtonsoft.Json.Linq.JObject jObject)
-                {
-                    await LogService.WriteToLogAsync($"[{DateTime.Now}] Detected JSON object. Properties: {string.Join(", ", jObject.Properties().Select(p => p.Name))}");
-                    var arrayProperty = jObject.Properties().FirstOrDefault(p => p.Value is Newtonsoft.Json.Linq.JArray);
-                    if (arrayProperty != null)
-                        processedJsonText = arrayProperty.Value.ToString();
-                    else
-                        processedJsonText = $"[{processedText}]";
-                }
-            }
-            catch (JsonReaderException jsonReadEx)
-            {
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: JSON format is invalid - {jsonReadEx.Message}");
-                NotificationService.Notify(new NotificationMessage
-                {
-                    Severity = NotificationSeverity.Error,
-                    Summary = "JSON Format Error",
-                    Detail = "The text does not contain valid JSON.",
-                    Duration = 8000
-                });
-                return;
-            }
-
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] Processed JSON text (first 1000 chars): {processedJsonText?.Substring(0, Math.Min(1000, processedJsonText?.Length ?? 0))}");
-
-            var calculator = new CalculateProposal("/RFPResponseAPP", LogService);
-
-            List<RoomAssignment> assigned;
-            try
-            {
-                assigned = await calculator.CalculateAsync(processedJsonText);
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] Calculator.CalculateAsync completed successfully with {assigned?.Count ?? 0} results");
-            }
-            catch (FormatException formatEx)
-            {
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Format exception in CalculateAsync - {formatEx.Message}");
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {formatEx.StackTrace}");
-                NotificationService.Notify(new NotificationMessage
-                {
-                    Severity = NotificationSeverity.Error,
-                    Summary = "Data Format Error",
-                    Detail = $"Invalid data format detected: {formatEx.Message}. Please check the date/time or numeric values in your proposal.",
-                    Duration = 8000
-                });
-                return;
-            }
-            catch (Exception calcEx)
-            {
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in CalculateAsync - {calcEx.Message}");
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {calcEx.StackTrace}");
-                throw;
-            }
-
-            try
-            {
-                var capacityJson = await File.ReadAllTextAsync("/RFPResponseAPP/Capacity.json");
-                var capacity = JsonConvert.DeserializeObject<CapacityRoot>(capacityJson);
-                roomOptions = capacity?.Rooms?.Select(r => r.Name).OrderBy(n => n).ToList() ?? new List<string>();
-            }
-            catch (Exception ex)
-            {
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] WARNING: Unable to load Capacity.json - {ex.Message}");
-                roomOptions = new List<string>();
-            }
-
-            try
-            {
-                proposalRows = assigned.Select(a => new ProposalRow
-                {
-                    Name = a.Request?.Name ?? "Unknown",
-                    SelectedRoom = a.AssignedRoom ?? "",
-                    ManualRoom = string.Empty,
-                    StartDate = a.Request?.StartDate ?? DateTime.Today,
-                    StartTime = a.Request?.StartTime ?? TimeSpan.Zero,
-                    EndDate = a.Request?.EndDate ?? DateTime.Today,
-                    EndTime = a.Request?.EndTime ?? TimeSpan.Zero,
-                    RoomType = a.Request?.RoomType ?? "",
-                    Attendance = a.Request?.Attendance ?? 0,
-                    Notes = a.Request?.Notes ?? ""
-                }).ToList();
-                SortProposalRows();
-                await SaveProposalRowsAsync();
-            }
-            catch (Exception rowEx)
-            {
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception creating ProposalRow objects - {rowEx.Message}");
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {rowEx.StackTrace}");
-                throw;
-            }
-
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] CalculateProposal completed successfully with {assigned.Count} assignments");
-
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Success,
-                Summary = "Success",
-                Detail = "Calculation completed.",
-                Duration = 4000
-            });
-        }
-        catch (JsonException jsonEx)
-        {
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: JSON deserialization error in CalculateProposal - {jsonEx.Message}");
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: JSON error stack trace - {jsonEx.StackTrace}");
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Error,
-                Summary = "JSON Error",
-                Detail = $"Failed to parse JSON data: {jsonEx.Message}. Please ensure the proposal has been processed correctly.",
-                Duration = 8000
-            });
-        }
-        catch (Exception ex)
-        {
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in CalculateProposal - {ex.Message}");
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception type: {ex.GetType().Name}");
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {ex.StackTrace}");
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Error,
-                Summary = "Error",
-                Detail = ex.Message,
-                Duration = 8000
-            });
-        }
-        finally
-        {
-            InProgress = false;
-            StateHasChanged();
-        }
-    }
-
-    private async Task ReCalculateProposal()
-    {
-        try
-        {
-            InProgress = true;
-            StateHasChanged();
-
-            await CalculateRoomsForExistingRows();
-        }
-        catch (Exception ex)
-        {
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in ReCalculateProposal - {ex.Message}");
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {ex.StackTrace}");
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Error,
-                Summary = "Error",
-                Detail = $"Failed to calculate rooms: {ex.Message}",
-                Duration = 8000
-            });
-        }
-        finally
-        {
-            InProgress = false;
-            StateHasChanged();
-        }
-    }
-
-    private async Task DetectRoomRequests()
-    {
-        try
-        {
-            InProgress = true;
-            CurrentStatus = "Detect Rooms Requests (2-3 minutes)...";
-            StateHasChanged();
-
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ProcessOCRText method started");
-
-            var objOrchestratorMethods = new OrchestratorMethods(_SettingsService, LogService);
-            var settingsService = new SettingsService();
-
-            var Proposalprompt = await Http.GetStringAsync("Prompts/Proposal.prompt");
-            Proposalprompt = Proposalprompt.Replace("{{OCRResult}}", RFPText);
-
-            result = await objOrchestratorMethods.CallOpenAIAsync(settingsService, Proposalprompt);
-
-            processedText = $"[{result.Response}]";
-
-            if (result.Error == "")
-            {
-                CurrentStatus = "Calculate Proposal...";
-                StateHasChanged();
-
-                await CalculateProposal();
-            }
-            else
-            {
-                InProgress = false;
-                StateHasChanged();
-
-                await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: ProcessOCRText failed - {result.Error}");
-                NotificationService.Notify(new NotificationMessage
-                {
-                    Severity = NotificationSeverity.Error,
-                    Summary = "Error",
-                    Detail = $"Failed to process... {result.Error}",
-                    Duration = 4000
-                });
-            }
-        }
-        catch (Exception ex)
-        {
-            InProgress = false;
-            StateHasChanged();
-
-            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in ProcessOCRText - {ex.Message}");
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Error,
-                Summary = "Error",
-                Detail = ex.Message,
-                Duration = 8000
-            });
-        }
-    }
 
     public void Dispose()
     {

--- a/RFPResponsePOC/RFPResponsePOC.Client/Services/Calculations.cs
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Services/Calculations.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Radzen;
+using RFPResponseAPP.AI;
+using RFPResponseAPP.Client.Models;
+using RFPResponseAPP.Model;
+using RFPResponseAPP.Models;
+
+namespace RFPResponseAPP.Client.Services
+{
+    public static class Calculations
+    {
+        public static async Task<(AIResponse result, string processedText, List<ProposalRow> proposalRows, List<string> roomOptions)> DetectRoomRequests(
+            string rfpText,
+            HttpClient http,
+            SettingsService settingsService,
+            LogService logService,
+            NotificationService notificationService,
+            Func<Task> saveProposalRowsAsync,
+            Action sortProposalRows)
+        {
+            AIResponse result = new AIResponse();
+            string processedText = string.Empty;
+            List<ProposalRow> proposalRows = new();
+            List<string> roomOptions = new();
+
+            try
+            {
+                await logService.WriteToLogAsync($"[{DateTime.Now}] ProcessOCRText method started");
+
+                var objOrchestratorMethods = new OrchestratorMethods(settingsService, logService);
+                var localSettings = new SettingsService();
+
+                var proposalPrompt = await http.GetStringAsync("Prompts/Proposal.prompt");
+                proposalPrompt = proposalPrompt.Replace("{{OCRResult}}", rfpText);
+
+                result = await objOrchestratorMethods.CallOpenAIAsync(localSettings, proposalPrompt);
+
+                processedText = $"[{result.Response}]";
+
+                if (result.Error == "")
+                {
+                    var calcResult = await CalculateProposal(processedText, rfpText, logService, notificationService, saveProposalRowsAsync, sortProposalRows);
+                    proposalRows = calcResult.ProposalRows;
+                    roomOptions = calcResult.RoomOptions;
+                }
+                else
+                {
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: ProcessOCRText failed - {result.Error}");
+                    notificationService.Notify(new NotificationMessage
+                    {
+                        Severity = NotificationSeverity.Error,
+                        Summary = "Error",
+                        Detail = $"Failed to process... {result.Error}",
+                        Duration = 4000
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in ProcessOCRText - {ex.Message}");
+                notificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Error,
+                    Summary = "Error",
+                    Detail = ex.Message,
+                    Duration = 8000
+                });
+            }
+
+            return (result, processedText, proposalRows, roomOptions);
+        }
+
+        public static async Task<List<string>> ReCalculateProposal(List<ProposalRow> proposalRows, LogService logService, NotificationService notificationService)
+        {
+            try
+            {
+                return await CalculateRoomsForExistingRows(proposalRows, logService, notificationService);
+            }
+            catch (Exception ex)
+            {
+                await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in ReCalculateProposal - {ex.Message}");
+                await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {ex.StackTrace}");
+                notificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Error,
+                    Summary = "Error",
+                    Detail = $"Failed to calculate rooms: {ex.Message}",
+                    Duration = 8000
+                });
+                return new List<string>();
+            }
+        }
+
+        public static async Task<(List<ProposalRow> ProposalRows, List<string> RoomOptions)> CalculateProposal(
+            string processedText,
+            string rfpText,
+            LogService logService,
+            NotificationService notificationService,
+            Func<Task> saveProposalRowsAsync,
+            Action sortProposalRows)
+        {
+            try
+            {
+                await logService.WriteToLogAsync($"[{DateTime.Now}] CalculateProposal method started");
+                await logService.WriteToLogAsync($"[{DateTime.Now}] RFPText content length: {rfpText?.Length ?? 0}");
+                await logService.WriteToLogAsync($"[{DateTime.Now}] RFPText content (first 1000 chars): {rfpText?.Substring(0, Math.Min(1000, rfpText?.Length ?? 0))}");
+
+                string processedJsonText = processedText;
+
+                try
+                {
+                    var testParse = JsonConvert.DeserializeObject(processedText);
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] JSON parsing test successful. Object type: {testParse?.GetType().Name}");
+                    if (testParse is Newtonsoft.Json.Linq.JObject jObject)
+                    {
+                        await logService.WriteToLogAsync($"[{DateTime.Now}] Detected JSON object. Properties: {string.Join(", ", jObject.Properties().Select(p => p.Name))}");
+                        var arrayProperty = jObject.Properties().FirstOrDefault(p => p.Value is Newtonsoft.Json.Linq.JArray);
+                        if (arrayProperty != null)
+                            processedJsonText = arrayProperty.Value.ToString();
+                        else
+                            processedJsonText = $"[{processedText}]";
+                    }
+                }
+                catch (JsonReaderException jsonReadEx)
+                {
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: JSON format is invalid - {jsonReadEx.Message}");
+                    notificationService.Notify(new NotificationMessage
+                    {
+                        Severity = NotificationSeverity.Error,
+                        Summary = "JSON Format Error",
+                        Detail = "The text does not contain valid JSON.",
+                        Duration = 8000
+                    });
+                    return (new List<ProposalRow>(), new List<string>());
+                }
+
+                await logService.WriteToLogAsync($"[{DateTime.Now}] Processed JSON text (first 1000 chars): {processedJsonText?.Substring(0, Math.Min(1000, processedJsonText?.Length ?? 0))}");
+
+                var calculator = new CalculateProposal("/RFPResponseAPP", logService);
+
+                List<RoomAssignment> assigned;
+                try
+                {
+                    assigned = await calculator.CalculateAsync(processedJsonText);
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] Calculator.CalculateAsync completed successfully with {assigned?.Count ?? 0} results");
+                }
+                catch (FormatException formatEx)
+                {
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Format exception in CalculateAsync - {formatEx.Message}");
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {formatEx.StackTrace}");
+                    notificationService.Notify(new NotificationMessage
+                    {
+                        Severity = NotificationSeverity.Error,
+                        Summary = "Data Format Error",
+                        Detail = $"Invalid data format detected: {formatEx.Message}. Please check the date/time or numeric values in your proposal.",
+                        Duration = 8000
+                    });
+                    return (new List<ProposalRow>(), new List<string>());
+                }
+                catch (Exception calcEx)
+                {
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in CalculateAsync - {calcEx.Message}");
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {calcEx.StackTrace}");
+                    throw;
+                }
+
+                List<string> roomOptions;
+                try
+                {
+                    var capacityJson = await File.ReadAllTextAsync("/RFPResponseAPP/Capacity.json");
+                    var capacity = JsonConvert.DeserializeObject<CapacityRoot>(capacityJson);
+                    roomOptions = capacity?.Rooms?.Select(r => r.Name).OrderBy(n => n).ToList() ?? new List<string>();
+                }
+                catch (Exception ex)
+                {
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] WARNING: Unable to load Capacity.json - {ex.Message}");
+                    roomOptions = new List<string>();
+                }
+
+                List<ProposalRow> proposalRows;
+                try
+                {
+                    proposalRows = assigned.Select(a => new ProposalRow
+                    {
+                        Name = a.Request?.Name ?? "Unknown",
+                        SelectedRoom = a.AssignedRoom ?? "",
+                        ManualRoom = string.Empty,
+                        StartDate = a.Request?.StartDate ?? DateTime.Today,
+                        StartTime = a.Request?.StartTime ?? TimeSpan.Zero,
+                        EndDate = a.Request?.EndDate ?? DateTime.Today,
+                        EndTime = a.Request?.EndTime ?? TimeSpan.Zero,
+                        RoomType = a.Request?.RoomType ?? "",
+                        Attendance = a.Request?.Attendance ?? 0,
+                        Notes = a.Request?.Notes ?? ""
+                    }).ToList();
+                    sortProposalRows?.Invoke();
+                    if (saveProposalRowsAsync != null)
+                    {
+                        await saveProposalRowsAsync();
+                    }
+                }
+                catch (Exception rowEx)
+                {
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception creating ProposalRow objects - {rowEx.Message}");
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {rowEx.StackTrace}");
+                    throw;
+                }
+
+                await logService.WriteToLogAsync($"[{DateTime.Now}] CalculateProposal completed successfully with {assigned.Count} assignments");
+
+                notificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Success,
+                    Summary = "Success",
+                    Detail = "Calculation completed.",
+                    Duration = 4000
+                });
+
+                return (proposalRows, roomOptions);
+            }
+            catch (JsonException jsonEx)
+            {
+                await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: JSON deserialization error in CalculateProposal - {jsonEx.Message}");
+                await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: JSON error stack trace - {jsonEx.StackTrace}");
+                notificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Error,
+                    Summary = "JSON Error",
+                    Detail = $"Failed to parse JSON data: {jsonEx.Message}. Please ensure the proposal has been processed correctly.",
+                    Duration = 8000
+                });
+                return (new List<ProposalRow>(), new List<string>());
+            }
+            catch (Exception ex)
+            {
+                await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in CalculateProposal - {ex.Message}");
+                await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception type: {ex.GetType().Name}");
+                await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Stack trace - {ex.StackTrace}");
+                notificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Error,
+                    Summary = "Error",
+                    Detail = ex.Message,
+                    Duration = 8000
+                });
+                return (new List<ProposalRow>(), new List<string>());
+            }
+        }
+
+        public static async Task<List<string>> CalculateRoomsForExistingRows(List<ProposalRow> proposalRows, LogService logService, NotificationService notificationService)
+        {
+            try
+            {
+                await logService.WriteToLogAsync($"[{DateTime.Now}] CalculateRoomsForExistingRows started with {proposalRows?.Count ?? 0} rows");
+
+                if (proposalRows == null || !proposalRows.Any())
+                {
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] No existing proposal rows found");
+                    notificationService.Notify(new NotificationMessage
+                    {
+                        Severity = NotificationSeverity.Warning,
+                        Summary = "Warning",
+                        Detail = "No proposal rows found. Please add some rows or upload a proposal first.",
+                        Duration = 4000
+                    });
+                    return new List<string>();
+                }
+
+                var rowsNeedingRooms = proposalRows.Where(row => string.IsNullOrWhiteSpace(row.ManualRoom) && string.IsNullOrWhiteSpace(row.SelectedRoom)).ToList();
+
+                await logService.WriteToLogAsync($"[{DateTime.Now}] Found {rowsNeedingRooms.Count} rows needing room assignments");
+
+                if (!rowsNeedingRooms.Any())
+                {
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] No rows require room assignments");
+                    notificationService.Notify(new NotificationMessage
+                    {
+                        Severity = NotificationSeverity.Info,
+                        Summary = "Info",
+                        Detail = "All rows already have room assignments or manual room overrides.",
+                        Duration = 4000
+                    });
+                    return new List<string>();
+                }
+
+                var requests = rowsNeedingRooms.Select(row => new RoomsRequest
+                {
+                    Name = row.Name ?? "Unknown",
+                    StartDate = row.StartDate,
+                    StartTime = row.StartTime,
+                    EndDate = row.EndDate,
+                    EndTime = row.EndTime,
+                    RoomType = row.RoomType ?? "",
+                    Attendance = row.Attendance,
+                    Notes = row.Notes ?? ""
+                }).ToList();
+
+                var requestsJson = JsonConvert.SerializeObject(requests);
+                await logService.WriteToLogAsync($"[{DateTime.Now}] Created requests JSON for calculation: {requestsJson.Substring(0, Math.Min(500, requestsJson.Length))}");
+
+                var calculator = new CalculateProposal("/RFPResponseAPP", logService);
+                var assignments = await calculator.CalculateAsync(requestsJson);
+                await logService.WriteToLogAsync($"[{DateTime.Now}] Calculator returned {assignments?.Count ?? 0} assignments");
+
+                var assignmentDict = assignments.ToDictionary(a => a.Request?.Name ?? "", a => a.AssignedRoom);
+
+                foreach (var row in rowsNeedingRooms)
+                {
+                    if (assignmentDict.TryGetValue(row.Name ?? "", out var assignedRoom) && !string.IsNullOrWhiteSpace(assignedRoom))
+                    {
+                        row.SelectedRoom = assignedRoom;
+                        await logService.WriteToLogAsync($"[{DateTime.Now}] Assigned room '{assignedRoom}' to row '{row.Name}'");
+                    }
+                    else
+                    {
+                        await logService.WriteToLogAsync($"[{DateTime.Now}] No room assigned for row '{row.Name}'");
+                    }
+                }
+
+                List<string> roomOptions;
+                try
+                {
+                    var capacityJson = await File.ReadAllTextAsync("/RFPResponseAPP/Capacity.json");
+                    var capacity = JsonConvert.DeserializeObject<CapacityRoot>(capacityJson);
+                    roomOptions = capacity?.Rooms?.Select(r => r.Name).OrderBy(n => n).ToList() ?? new List<string>();
+                }
+                catch (Exception ex)
+                {
+                    await logService.WriteToLogAsync($"[{DateTime.Now}] WARNING: Unable to load Capacity.json - {ex.Message}");
+                    roomOptions = new List<string>();
+                }
+
+                int assignedCount = rowsNeedingRooms.Count(r => !string.IsNullOrWhiteSpace(r.SelectedRoom));
+                await logService.WriteToLogAsync($"[{DateTime.Now}] CalculateRoomsForExistingRows completed - assigned {assignedCount} of {rowsNeedingRooms.Count} rooms");
+
+                return roomOptions;
+            }
+            catch (Exception ex)
+            {
+                await logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in CalculateRoomsForExistingRows - {ex.Message}");
+                return new List<string>();
+            }
+        }
+    }
+}

--- a/RFPResponsePOC/RFPResponsePOC.Client/Services/QuestionProcessing.cs
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Services/QuestionProcessing.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using RFPResponseAPP.AI;
+using RFPResponseAPP.Client.Models;
+using RFPResponseAPP.Model;
+
+namespace RFPResponseAPP.Client.Services
+{
+    public class QuestionProcessing
+    {
+        private readonly HttpClient _http;
+        private readonly SettingsService _settingsService;
+        private readonly LogService _logService;
+
+        public QuestionProcessing(HttpClient http, SettingsService settingsService, LogService logService)
+        {
+            _http = http;
+            _settingsService = settingsService;
+            _logService = logService;
+        }
+
+        public async Task<List<QuestionResponse>> IdentifyQuestions(string rfpText)
+        {
+            var identifiedQuestions = new List<QuestionResponse>();
+
+            try
+            {
+                var prompt = await _http.GetStringAsync("Prompts/IdentifyQuestions.prompt");
+                prompt = prompt.Replace("{{RFPText}}", rfpText ?? string.Empty);
+
+                await _logService.WriteToLogAsync($"[{DateTime.Now}] IdentifyQuestions: Sending prompt to AI...");
+
+                var objOrchestratorMethods = new OrchestratorMethods(_settingsService, _logService);
+                var settingsService = new SettingsService();
+
+                var response = await objOrchestratorMethods.CallOpenAIAsync(settingsService, prompt);
+
+                await _logService.WriteToLogAsync($"[{DateTime.Now}] IdentifyQuestions: AI response length: {response.Response?.Length ?? 0}");
+
+                if (string.IsNullOrWhiteSpace(response.Error))
+                {
+                    await _logService.WriteToLogAsync($"[{DateTime.Now}] IdentifyQuestions: Attempting to deserialize JSON response");
+                    identifiedQuestions = JsonConvert.DeserializeObject<List<QuestionResponse>>(response.Response) ?? new List<QuestionResponse>();
+                    await _logService.WriteToLogAsync($"[{DateTime.Now}] IdentifyQuestions: Deserialized {identifiedQuestions.Count} questions");
+                }
+                else
+                {
+                    await _logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: IdentifyQuestions failed - {response.Error}");
+                }
+            }
+            catch (Exception ex)
+            {
+                await _logService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in IdentifyQuestions - {ex.Message}");
+            }
+
+            return identifiedQuestions;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract IdentifyQuestions logic into new QuestionProcessing service
- centralize room request detection and proposal calculations in Calculations service
- update Response component to use new services and add recalculation handler

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68bccd91aba48333aab99791ed357762